### PR TITLE
Only add default directives if `run` is present

### DIFF
--- a/src/lib/vite.js
+++ b/src/lib/vite.js
@@ -18,7 +18,7 @@ function lqip(cfg, ctx) {
 
 function main(overrides = {}) {
   return imagetools({
-    defaultDirectives: () => new URLSearchParams('width=480;1024;1920&format=avif;webp;jpg'),
+    defaultDirectives: (url) => url.searchParams.has('run') ? new URLSearchParams('width=480;1024;1920&format=avif;webp;jpg') : new URLSearchParams(''),
     extendTransforms: (builtins) => [...builtins, lqip],
     extendOutputFormats: (builtinOutputFormats) => ({
       ...builtinOutputFormats,

--- a/src/routes/test/+page.svelte
+++ b/src/routes/test/+page.svelte
@@ -2,13 +2,15 @@
 import testBasic from '../cat01.jpg?run'
 import testNoLqip from '../cat01.jpg?lqip=0&run'
 import testWidthOverride from '../cat01.jpg?width=480;1024&run'
+import testDefault from '../cat01.jpg'
 
 const s = (obj = {}) => JSON.stringify(obj)
 
 const tests = [
   { id: 'basic', name: 'default variants are generated', view: s(testBasic) },
   { id: 'nolqip', name: 'no lqip', view: s(testNoLqip) },
-  { id: 'width', name: 'width override', view: s(testWidthOverride) }
+  { id: 'width', name: 'width override', view: s(testWidthOverride) },
+  { id: 'default', name: 'returns a path by default', view: s(testDefault) }
 ]
 </script>
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -28,3 +28,9 @@ test('width override', async ({ page }) => {
   expect(data.filter((i) => i.width === 480).length).toBe(3)
   expect(data.filter((i) => i.width === 1024).length).toBe(3)
 })
+
+test('returns a path by default', async ({ page }) => {
+  await page.goto('/test')
+  const data = JSON.parse((await page.getByTestId('default').textContent()) || '')
+  expect(data).toBe(`/src/routes/cat01.jpg`)
+})


### PR DESCRIPTION
- Closes #10 
- Previously, omitting the `run` directive on imported images would result in an error when they were used in regular `<img>` tags as the image's source.
- As a quick solution, a ternary has been added to `defaultDirectives` to ensure that each URL includes a 'run' search parameter.
- I've also included a basic test to ensure that imported images which don't include any query params (as is standard Svelte usage) return the path to the image.