### PR TITLE
Add tree-shaking hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
       ]
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This adds `sideEffects: false` into `package.json` to hint to bundlers that individual components are safe to tree-shake. Fixes #27.