### PR TITLE
Fix transparent background

### DIFF
--- a/src/lib/FxReveal.svelte
+++ b/src/lib/FxReveal.svelte
@@ -17,7 +17,7 @@ let inview = false
 $: if (len(src)) {
   loaded = false
   const { lqip, src: s, w, h } = src.img
-  background = lqip ? lqipToBackground(lqip) : undefined
+  background = lqip && !loaded ? lqipToBackground(lqip) : undefined
   const { sources = {} } = src
   meta = { img: { src: s, w, h }, sources }
 } else {


### PR DESCRIPTION
Fix for https://github.com/zerodevx/svelte-img/issues/6

Don't show blurred background if image is loaded