### PR TITLE
Workaround for CSP issue with Svelte5

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "auto",
   "useTabs": false,
   "singleQuote": true,
   "trailingComma": "none",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@zerodevx/svelte-img",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerodevx/svelte-img",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
+        "@zerodevx/svelte-img": "file:",
         "vite-imagetools": "^6.2.9"
       },
       "devDependencies": {
@@ -1634,6 +1635,10 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@zerodevx/svelte-img": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodevx/svelte-img",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "High-performance responsive/progressive images for SvelteKit",
   "author": "Jason Lee <jason@zerodevx.com>",
   "scripts": {
@@ -16,6 +16,7 @@
     "deploy": "npx gh-pages -d build -t -f"
   },
   "dependencies": {
+    "@zerodevx/svelte-img": "file:",
     "vite-imagetools": "^6.2.9"
   },
   "peerDependencies": {

--- a/src/lib/FxReveal.svelte
+++ b/src/lib/FxReveal.svelte
@@ -46,7 +46,7 @@ onMount(() => {
     on:enter={() => (inview = true)}
   >
     <Img {...$$restProps} bind:ref on:load on:load={() => (loaded = true)} on:click src={meta} />
-    <div class="lqip" style:background />
+    <div class="lqip" style:background></div>
   </div>
 {/if}
 

--- a/src/lib/SvelteImg.svelte
+++ b/src/lib/SvelteImg.svelte
@@ -1,4 +1,5 @@
 <script>
+import { onMount } from 'svelte'
 import Picture from './Picture.svelte'
 import { len, lqipToBackground } from './utils.js'
 
@@ -54,6 +55,20 @@ $: if (len(img)) {
   const { lqip } = img
   background = lqip ? lqipToBackground(lqip) : undefined
 }
+onMount(() => {
+  if (!ref) return
+
+  const restProps = $$restProps
+  Object.entries(restProps).forEach(([key, value]) => {
+    if (key.startsWith('on:')) {
+      // Handle event listeners dynamically (on:click, on:load, etc.)
+      ref.addEventListener(key.slice(3), value)
+    } else {
+      // Apply other attributes such as style, class, etc.
+      ref.setAttribute(key, value)
+    }
+  })
+})
 </script>
 
 <!-- @component
@@ -68,11 +83,15 @@ High-performance responsive/progressive images for SvelteKit.
 <Img {src} alt="cute cat" />
 -->
 
+{#if false}
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <img {...$$restProps} />
+{/if}
+
 {#if len(img)}
   <Picture {sources} {sizes}>
-    <!-- svelte-ignore a11y-missing-attribute a11y-no-noninteractive-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute a11y-no-noninteractive-element-interactions a11y-click-events-have-key-events -->
     <img
-      {...$$restProps}
       {loading}
       {decoding}
       width={width || img.w || undefined}


### PR DESCRIPTION
Currently, Svelte 5 does not provide robust support for combining $$restProps with event bubbling.

This workaround addresses [issue #56](https://github.com/zerodevx/svelte-img/issues/56), enabling the use of SvelteImg component with both Svelte 4 and Svelte 5.

> REM: It might lack reactivity if binding is used in $$restProps